### PR TITLE
Wrap class in a block

### DIFF
--- a/lib/Test/Builder/Output.pm
+++ b/lib/Test/Builder/Output.pm
@@ -92,7 +92,7 @@ For further information, please see LICENSE or visit
 =end pod
 
 #= Handles output operations for Test::Builder objects
-class Test::Builder::Output;
+class Test::Builder::Output {
     has $!stdout;    #= Filehandle used by write()
     has $!stderr;    #= Filehandle used by diag()
 
@@ -116,6 +116,7 @@ class Test::Builder::Output;
 
         $!stderr.say($msg);
     }
+}
 
 # vim: ft=perl6
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` blockless declarations.  An alternative is to
wrap the class, role, grammar or module in a block, as done in this change,
since it fits the code's current visual structure.

Code still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
