### PR TITLE
Fix virtual call error

### DIFF
--- a/lib/Test/Builder/Plan.pm
+++ b/lib/Test/Builder/Plan.pm
@@ -98,7 +98,7 @@ role Test::Builder::Plan::Generic {
 class Test::Builder::Plan does Test::Builder::Plan::Generic {
     has Int $.expected is rw;    #= Number of tests that "should" be run
 
-    submethod BUILD(:$.expected = 0) {
+    submethod BUILD(:$!expected = 0) {
         die 'Invalid or missing plan!' unless self.expected.defined;
     }
 


### PR DESCRIPTION
Original error:
===SORRY!=== Error while compiling lib/Test/Builder/Plan.pm
Virtual call $.expected may not be used on partially constructed objects
at lib/Test/Builder/Plan.pm:101
------>     submethod BUILD(:$.expected⏏ = 0) {
    expecting any of:
        shape declaration
