### PR TITLE
Type mismatch and failed look up were fixed

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -122,7 +122,7 @@ Copyright (C) 2011, Kevin Polulak <kpolulak@gmail.com>.
 
 This program is distributed under the terms of the Artistic License 2.0.
 
-For further information, please see LICENSE or visit 
+For further information, please see LICENSE or visit
 <http://www.perlfoundation.org/attachment/legal/artistic-2_0.txt>.
 
 =end pod
@@ -138,7 +138,7 @@ my Test::Builder $TEST_BUILDER;
 
 class Test::Builder:auth<soh_cah_toa>:ver<0.0.1> {
     #= Stack containing results of each test
-    has Test::Builder::Test          @!results;
+    has                              @!results;
 
     #= Sets up number of tests to rune
     has Test::Builder::Plan::Generic $!plan;
@@ -164,9 +164,10 @@ class Test::Builder:auth<soh_cah_toa>:ver<0.0.1> {
 
     #= Declares that no more tests need to be run
     method done() {
-        $.done_testing = Bool::True;
+        $.done_testing = True;
 
-        my $footer = $!plan.footer(+@!results);
+        # "Cannot look up attributes in a type object" error check.
+        my $footer = $!plan.footer(+@!results) if ?$!plan;
         $!output.write($footer) if $footer;
     }
 
@@ -286,4 +287,3 @@ END {
 }
 
 # vim: ft=perl6
-

--- a/t/01-load.t
+++ b/t/01-load.t
@@ -3,10 +3,12 @@ use v6;
 use Test;
 use Test::Builder;
 
-plan 1;
+plan 2;
 
 # Verify that module is loaded properly
 ok 1, 'Load module';
 
-# vim: ft=perl6
+my Test::Builder $tb .= new;
+ok $tb, 'Instance was created';
 
+# vim: ft=perl6


### PR DESCRIPTION
Since for now this package is somewhat broken, I played with it a bit and fixed two bugs that blocked normal execution of program.
First was

```
Type check failed in assignment to @!results; expected Test::Builder::Test but got Test::Builder::Test::Fail (Test::Builder::Test::...)
  in method report_test at /home/sena/.rakudobrew/moar-nom/install/share/perl6/site/sources/F53A996F457FB10FA78AD8ADAF4A80774844937A line 270
  in method ok at /home/sena/.rakudobrew/moar-nom/install/share/perl6/site/sources/F53A996F457FB10FA78AD8ADAF4A80774844937A line 196
  in sub notabs-ok at lib/Test/NoTabs.pm6 line 36
  in block <unit> at lib/Test/NoTabs.pm6 line 24

1..0
```

when we pushed into results array failed test. Second was "Cannot look up attributes in a type object", if $!plan variable wasn't set properly.

Tests are coming too, so don't merge this pull request yet.
