### PR TITLE
Add Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: perl6
+
+perl6:
+    - latest
+
+install:
+    - rakudobrew build-panda
+    - panda installdeps .


### PR DESCRIPTION
Oddly enough, the test suite passes on my local system, but not on the Travis infrastructure, hence this PR is submitted partially as adding a feature to the repo and partially as an issue to show that there's a problem.  The error produced on Travis is:

```
t/01-load.t .. ===SORRY!===
Type 'Test::Builder::Plan::Generic' is not declared
at /home/travis/build/paultcochrane/p6-test-builder/lib/Test/Builder.pm (Test::Builder):144
------>     has Test::Builder::Plan::Generic⏏ $!plan;
Malformed has
at /home/travis/build/paultcochrane/p6-test-builder/lib/Test/Builder.pm (Test::Builder):144
------>     has Test::Builder::Plan::⏏Generic $!plan;
```

which is, well, strange, since Test::Builder::Plan::Generic exists and should be available via the use statement to Test::Builder::Plan in the test file.  Unfortunately, I've no idea what the underlying problem is, nor how to fix it :-/  Nevertheless, hopefully this gives someone else sufficient information to start debugging the issue and hopefully to resolve it.