### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,18 +1,20 @@
 {
-    "perl"        : "6.*",
-    "name"        : "Test::Builder",
-    "version"     : "0.0.1",
-    "description" : "Flexible framework for building TAP test libraries",
-    "provides"    : {
-        "Test::Builder"         : "lib/Test/Builder.pm",
-        "Test::Builder::Plan"   : "lib/Test/Builder/Plan.pm",
-        "Test::Builder::Test"   : "lib/Test/Builder/Test.pm",
-        "Test::Builder::Output" : "lib/Test/Builder/Output.pm"
-    },
-    "author"      : "Kevin Polulak",
-    "authority"   : "soh-cah-toa",
-    "depends"     : [],
-    "source-type" : "git",
-    "source-url"  : "git://github.com/perl6-community-modules/p6-test-builder.git"
+  "name": "Test::Builder",
+  "source-url": "git://github.com/perl6-community-modules/p6-test-builder.git",
+  "authority": "soh-cah-toa",
+  "perl": "6.*",
+  "source-type": "git",
+  "author": "Kevin Polulak",
+  "depends": [
+    
+  ],
+  "license": "Artistic-2.0",
+  "provides": {
+    "Test::Builder::Test": "lib/Test/Builder/Test.pm",
+    "Test::Builder::Plan": "lib/Test/Builder/Plan.pm",
+    "Test::Builder::Output": "lib/Test/Builder/Output.pm",
+    "Test::Builder": "lib/Test/Builder.pm"
+  },
+  "version": "0.0.1",
+  "description": "Flexible framework for building TAP test libraries"
 }
-


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license